### PR TITLE
Cross page manipulation

### DIFF
--- a/todos/reflexes/todo_reflex.py
+++ b/todos/reflexes/todo_reflex.py
@@ -1,4 +1,5 @@
 from sockpuppet import reflex
+from sockpuppet.channel import Channel
 
 from todos.models import Todo
 
@@ -6,6 +7,15 @@ from todos.models import Todo
 class TodoReflex(reflex.Reflex):
     def add_todo(self, step=1):
         Todo.objects.create(description='NewReflexTest')
+        channel_id = self.get_channel_id()
+
+        channel = Channel(name=channel_id, identifier='{"channel":"StimulusReflex::Channel"}')
+        channel.morph({
+            'selector': '#todo-counter',
+            'html': 'hello',
+            'children_only': True,
+        })
+        channel.broadcast()
 
     def reload(self):
         pass

--- a/todos/templates/index.html
+++ b/todos/templates/index.html
@@ -5,5 +5,5 @@
     <a  href="#"
         data-controller="counter"
         data-action="click->counter#increment"
-    >Increment {{ count }}</a>
+    >Increment <span id="todo-counter">{{ count }}</span></a>
 </body>


### PR DESCRIPTION
So what this does here is that once we add a new reflex we also make a morph to the the selector `#todo-counter`. This selector doesn't exist on the page where we add the reflex, however the selector exists on `todos/counter`. So when this happens we modify the html fragment that is selected and thus adds `hello` to there. 

Note that the below implementation only works if the user is logged in, if it is an anonymous user it will have two different session keys in the two different tabs. So if you want this to work for anon users you will need the users to subscribe to a generic channel name. 